### PR TITLE
feat: add stable and development update tracking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,10 @@ jobs:
       - name: Cross-compile
         env:
           VERSION: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
         run: |
           mkdir -p dist
-          LDFLAGS="-s -w -X github.com/floreabogdan/birdy/internal/buildinfo.Version=${VERSION}"
+          LDFLAGS="-s -w -X github.com/floreabogdan/birdy/internal/buildinfo.Version=${VERSION} -X github.com/floreabogdan/birdy/internal/buildinfo.Commit=${COMMIT}"
           targets="linux/amd64 linux/arm64 linux/arm freebsd/amd64 darwin/amd64 darwin/arm64"
           for t in $targets; do
             export GOOS=${t%/*} GOARCH=${t#*/} CGO_ENABLED=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Stable and development update tracking.** A new System → Updates page shows
+  the installed version and commit, checks either the latest published release
+  or upstream `main`, and reports when a newer build is available. Checks are
+  bounded and cached; installation remains an explicit operator action.
+
 ## [0.3.8] - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ go install github.com/floreabogdan/birdy/cmd/birdy@latest
 Or cross-compile from anywhere and copy one file to the router:
 
 ```sh
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o birdy ./cmd/birdy
+COMMIT=$(git rev-parse HEAD)
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
+  -ldflags="-s -w -X github.com/floreabogdan/birdy/internal/buildinfo.Commit=$COMMIT" \
+  -o birdy ./cmd/birdy
 scp birdy root@router:/usr/local/bin/birdy
 ```
 </details>
@@ -223,6 +226,8 @@ things follow from that, and both are one setting away:
 - Live BIRD-code preview on every editor: the generated config updates as you type, before you save
 - Every table paginated with numbered pages — the route browsers, the timeline, the apply history, and
   each library list
+- Stable or development update tracking in the panel, with the installed build and available upstream
+  release or commit shown without allowing the privileged web process to self-update
 
 **Model**
 - Peers with roles (upstream, IX peer, customer, iBGP), which drive automatic origin tagging

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -143,7 +143,10 @@ sudo install "$(go env GOPATH)/bin/birdy" /usr/local/bin/birdy
 Or cross-compile from your workstation and copy one file to the router:
 
 ```sh
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o birdy ./cmd/birdy
+COMMIT=$(git rev-parse HEAD)
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
+  -ldflags="-s -w -X github.com/floreabogdan/birdy/internal/buildinfo.Commit=$COMMIT" \
+  -o birdy ./cmd/birdy
 scp birdy user@router:/tmp/birdy
 ssh user@router 'sudo install /tmp/birdy /usr/local/bin/birdy'
 ```
@@ -676,6 +679,13 @@ button.
   snapshot is taken nightly and can be downloaded on demand; the **backup bundle**
   also includes the rendered config. A snapshot can be staged for restore (applied
   on the next restart).
+- **Updates** — under System → Updates, choose **Stable releases** to compare the
+  installed version with GitHub's latest release, or **Development branch** to
+  compare the embedded build commit with upstream `main`. Results are cached for
+  15 minutes. The setting controls notifications only: birdy does not replace its
+  own executable or run code fetched by the web process. Development builds must
+  embed their source revision with the documented build `-ldflags` for an exact
+  comparison.
 
 ---
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -5,3 +5,7 @@ package buildinfo
 // tag via -ldflags "-X github.com/floreabogdan/birdy/internal/buildinfo.Version=...".
 // A source build leaves it at this default.
 var Version = "0.3.9-dev"
+
+// Commit identifies the exact source revision for development-channel update
+// checks. Release builds may leave it empty because their version tag is enough.
+var Commit = "unknown"

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -8,7 +8,7 @@ import (
 
 // schemaVersion is the migration level this build expects. Bump it and add a
 // case to migrate() when the shape of an existing database has to change.
-const schemaVersion = 30
+const schemaVersion = 31
 
 // migrate brings an existing database up to schemaVersion. The CREATE TABLE
 // statements in schema.go are all IF NOT EXISTS and run unconditionally, so
@@ -396,6 +396,14 @@ func migrate(db *sql.DB) error {
 			if _, err := tx.Exec(`UPDATE settings SET kernel_export_bgp_v4 = 1, kernel_export_bgp_v6 = 1 WHERE id = 1`); err != nil {
 				return err
 			}
+		}
+	}
+
+	if version < 31 {
+		// Update checks track either signed stable releases or the main
+		// development branch. Stable is the conservative upgrade default.
+		if err := ensureColumn(tx, "settings", "update_channel", `ALTER TABLE settings ADD COLUMN update_channel TEXT NOT NULL DEFAULT 'stable'`); err != nil {
+			return err
 		}
 	}
 

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS settings (
 	webhook_url      TEXT NOT NULL DEFAULT '',
 	kernel_export_bgp_v4 INTEGER NOT NULL DEFAULT 0,
 	kernel_export_bgp_v6 INTEGER NOT NULL DEFAULT 0,
+	update_channel   TEXT NOT NULL DEFAULT 'stable',
 	created_at       TEXT NOT NULL,
 	updated_at       TEXT NOT NULL
 );

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -35,6 +35,7 @@ type Settings struct {
 	// route for each prefix into the host FIB. They default off.
 	KernelExportBGPV4 bool
 	KernelExportBGPV6 bool
+	UpdateChannel     string
 
 	// RawConfig is appended verbatim to the end of the generated bird.conf.
 	// The escape hatch for everything birdy does not model — BFD, extra tables,
@@ -106,11 +107,12 @@ func (s *Store) GetSettings() (Settings, bool, error) {
 		SELECT router_label, local_asn, router_id, bird_socket_path, listen_addr, webhook_url,
 		       rr_cluster_id, kernel_prefsrc_v4, kernel_prefsrc_v6,
 		       kernel_export_bgp_v4, kernel_export_bgp_v6,
-		       raw_config, applied_config_hash, access_whitelist
+		       update_channel, raw_config, applied_config_hash, access_whitelist
 		FROM settings WHERE id = 1`)
 	err := row.Scan(&st.RouterLabel, &st.LocalASN, &st.RouterID, &st.BirdSocketPath,
 		&st.ListenAddr, &st.WebhookURL, &st.RRClusterID, &st.KernelPrefSrcV4, &st.KernelPrefSrcV6,
-		&st.KernelExportBGPV4, &st.KernelExportBGPV6, &st.RawConfig, &st.AppliedConfigHash,
+		&st.KernelExportBGPV4, &st.KernelExportBGPV6, &st.UpdateChannel,
+		&st.RawConfig, &st.AppliedConfigHash,
 		&st.AccessWhitelist)
 	if err == sql.ErrNoRows {
 		return Settings{}, false, nil
@@ -127,8 +129,9 @@ func (s *Store) SaveSettings(st Settings) error {
 	_, err := s.db.Exec(`
 		INSERT INTO settings (id, router_label, local_asn, router_id, bird_socket_path, listen_addr,
 		                      webhook_url, rr_cluster_id, kernel_prefsrc_v4, kernel_prefsrc_v6,
-		                      kernel_export_bgp_v4, kernel_export_bgp_v6, raw_config, created_at, updated_at)
-		VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		                      kernel_export_bgp_v4, kernel_export_bgp_v6, update_channel,
+		                      raw_config, created_at, updated_at)
+		VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			router_label = excluded.router_label,
 			local_asn = excluded.local_asn,
@@ -141,13 +144,39 @@ func (s *Store) SaveSettings(st Settings) error {
 			kernel_prefsrc_v6 = excluded.kernel_prefsrc_v6,
 			kernel_export_bgp_v4 = excluded.kernel_export_bgp_v4,
 			kernel_export_bgp_v6 = excluded.kernel_export_bgp_v6,
+			update_channel = excluded.update_channel,
 			raw_config = excluded.raw_config,
 			updated_at = excluded.updated_at
 	`, st.RouterLabel, st.LocalASN, st.RouterID, st.BirdSocketPath, st.ListenAddr, st.WebhookURL,
 		st.RRClusterID, st.KernelPrefSrcV4, st.KernelPrefSrcV6, st.KernelExportBGPV4,
-		st.KernelExportBGPV6, st.RawConfig, ts, ts)
+		st.KernelExportBGPV6, normalizedUpdateChannel(st.UpdateChannel), st.RawConfig, ts, ts)
 	if err != nil {
 		return fmt.Errorf("store: save settings: %w", err)
+	}
+	return nil
+}
+
+func normalizedUpdateChannel(channel string) string {
+	if strings.TrimSpace(channel) == "development" {
+		return "development"
+	}
+	return "stable"
+}
+
+// SaveUpdateChannel changes only the selected update feed so the updates form
+// cannot overwrite router identity or configuration fields.
+func (s *Store) SaveUpdateChannel(channel string) error {
+	channel = normalizedUpdateChannel(channel)
+	ts := now()
+	_, err := s.db.Exec(`
+		INSERT INTO settings (id, update_channel, created_at, updated_at)
+		VALUES (1, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			update_channel = excluded.update_channel,
+			updated_at = excluded.updated_at
+	`, channel, ts, ts)
+	if err != nil {
+		return fmt.Errorf("store: save update channel: %w", err)
 	}
 	return nil
 }

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -46,6 +46,7 @@ func TestSettingsKernelPrefSrcRoundTrip(t *testing.T) {
 		KernelPrefSrcV6:   "2001:db8::1",
 		KernelExportBGPV4: true,
 		KernelExportBGPV6: true,
+		UpdateChannel:     "development",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -58,5 +59,40 @@ func TestSettingsKernelPrefSrcRoundTrip(t *testing.T) {
 	}
 	if !got.KernelExportBGPV4 || !got.KernelExportBGPV6 {
 		t.Errorf("kernel BGP export flags not persisted: %+v", got)
+	}
+	if got.UpdateChannel != "development" {
+		t.Errorf("update channel not persisted: %+v", got)
+	}
+}
+
+func TestSaveUpdateChannelIsScoped(t *testing.T) {
+	s := openTest(t)
+	want := Settings{RouterID: "192.0.2.1", UpdateChannel: "stable"}
+	if err := s.SaveSettings(want); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveUpdateChannel("development"); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := s.GetSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UpdateChannel != "development" || got.RouterID != want.RouterID {
+		t.Fatalf("scoped update changed unrelated settings: %+v", got)
+	}
+}
+
+func TestSaveUpdateChannelCreatesSettingsRow(t *testing.T) {
+	s := openTest(t)
+	if err := s.SaveUpdateChannel("development"); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.GetSettings()
+	if err != nil || !ok {
+		t.Fatalf("get settings: ok=%v err=%v", ok, err)
+	}
+	if got.UpdateChannel != "development" {
+		t.Fatalf("update channel = %q", got.UpdateChannel)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -36,6 +36,7 @@ func TestSettingsRoundTrip(t *testing.T) {
 		// access_whitelist is managed by SaveAccessWhitelist, not SaveSettings, so
 		// a fresh row carries its column default.
 		AccessWhitelist: "0.0.0.0/0",
+		UpdateChannel:   "stable",
 	}
 	if err := s.SaveSettings(want); err != nil {
 		t.Fatal(err)

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -1,0 +1,193 @@
+// Package updatecheck compares the running build with Birdy's stable release
+// or development branch using the public GitHub API.
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ChannelStable      = "stable"
+	ChannelDevelopment = "development"
+	defaultAPIBase     = "https://api.github.com/repos/floreabogdan/birdy"
+	maxResponseBytes   = 1 << 20
+)
+
+type Result struct {
+	Channel        string
+	CurrentVersion string
+	CurrentCommit  string
+	LatestVersion  string
+	LatestCommit   string
+	URL            string
+	Available      bool
+	CheckedAt      time.Time
+}
+
+type cachedResult struct {
+	result Result
+	err    error
+}
+
+type Client struct {
+	BaseURL string
+	HTTP    *http.Client
+	TTL     time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cachedResult
+}
+
+func New() *Client {
+	return &Client{
+		BaseURL: defaultAPIBase,
+		HTTP:    &http.Client{Timeout: 8 * time.Second},
+		TTL:     15 * time.Minute,
+		cache:   make(map[string]cachedResult),
+	}
+}
+
+func ValidChannel(channel string) bool {
+	return channel == ChannelStable || channel == ChannelDevelopment
+}
+
+func (c *Client) Check(ctx context.Context, channel, currentVersion, currentCommit string) (Result, error) {
+	if !ValidChannel(channel) {
+		return Result{}, fmt.Errorf("update check: unsupported channel %q", channel)
+	}
+	key := channel + "\x00" + currentVersion + "\x00" + currentCommit
+	c.mu.Lock()
+	if cached, ok := c.cache[key]; ok && time.Since(cached.result.CheckedAt) < c.ttl() {
+		c.mu.Unlock()
+		return cached.result, cached.err
+	}
+	c.mu.Unlock()
+
+	result, err := c.check(ctx, channel, currentVersion, currentCommit)
+	c.mu.Lock()
+	if c.cache == nil {
+		c.cache = make(map[string]cachedResult)
+	}
+	c.cache[key] = cachedResult{result: result, err: err}
+	c.mu.Unlock()
+	return result, err
+}
+
+func (c *Client) ttl() time.Duration {
+	if c.TTL <= 0 {
+		return 15 * time.Minute
+	}
+	return c.TTL
+}
+
+func (c *Client) check(ctx context.Context, channel, currentVersion, currentCommit string) (Result, error) {
+	result := Result{
+		Channel: channel, CurrentVersion: currentVersion,
+		CurrentCommit: currentCommit, CheckedAt: time.Now(),
+	}
+	if channel == ChannelStable {
+		var release struct {
+			TagName string `json:"tag_name"`
+			HTMLURL string `json:"html_url"`
+		}
+		if err := c.getJSON(ctx, "/releases/latest", &release); err != nil {
+			return result, err
+		}
+		result.LatestVersion = strings.TrimPrefix(release.TagName, "v")
+		result.URL = release.HTMLURL
+		result.Available = stableAvailable(currentVersion, result.LatestVersion)
+		return result, nil
+	}
+
+	var commit struct {
+		SHA     string `json:"sha"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := c.getJSON(ctx, "/commits/main", &commit); err != nil {
+		return result, err
+	}
+	result.LatestCommit = commit.SHA
+	result.URL = commit.HTMLURL
+	result.Available = currentCommit == "" || currentCommit == "unknown" ||
+		!strings.HasPrefix(commit.SHA, currentCommit)
+	return result, nil
+}
+
+func (c *Client) getJSON(ctx context.Context, path string, dst any) error {
+	base := strings.TrimRight(c.BaseURL, "/")
+	if base == "" {
+		base = defaultAPIBase
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "birdy-update-check")
+	client := c.HTTP
+	if client == nil {
+		client = &http.Client{Timeout: 8 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("update check: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("update check: GitHub returned HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("update check: read response: %w", err)
+	}
+	if len(body) > maxResponseBytes {
+		return fmt.Errorf("update check: response exceeds 1 MiB")
+	}
+	if err := json.Unmarshal(body, dst); err != nil {
+		return fmt.Errorf("update check: decode response: %w", err)
+	}
+	return nil
+}
+
+func stableAvailable(current, latest string) bool {
+	if strings.Contains(current, "-dev") {
+		return true
+	}
+	cur, okCur := semverTuple(current)
+	next, okNext := semverTuple(latest)
+	if !okCur || !okNext {
+		return strings.TrimPrefix(current, "v") != strings.TrimPrefix(latest, "v")
+	}
+	for i := range cur {
+		if next[i] != cur[i] {
+			return next[i] > cur[i]
+		}
+	}
+	return false
+}
+
+func semverTuple(version string) ([3]int, bool) {
+	var out [3]int
+	version = strings.TrimPrefix(strings.TrimSpace(version), "v")
+	version = strings.SplitN(version, "-", 2)[0]
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return out, false
+	}
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return out, false
+		}
+		out[i] = n
+	}
+	return out, true
+}

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -1,0 +1,58 @@
+package updatecheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStableAndDevelopmentChecks(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch r.URL.Path {
+		case "/releases/latest":
+			w.Write([]byte(`{"tag_name":"v0.3.8","html_url":"https://example/release"}`))
+		case "/commits/main":
+			w.Write([]byte(`{"sha":"abcdef1234567890","html_url":"https://example/commit"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	c := &Client{BaseURL: srv.URL, HTTP: srv.Client(), TTL: time.Hour}
+
+	stable, err := c.Check(context.Background(), ChannelStable, "0.3.7", "")
+	if err != nil || !stable.Available || stable.LatestVersion != "0.3.8" {
+		t.Fatalf("stable result = %+v, err %v", stable, err)
+	}
+	dev, err := c.Check(context.Background(), ChannelDevelopment, "0.3.9-dev", "abcdef1")
+	if err != nil || dev.Available {
+		t.Fatalf("development result = %+v, err %v", dev, err)
+	}
+	if _, err := c.Check(context.Background(), ChannelStable, "0.3.7", ""); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want one per channel due to cache", requests)
+	}
+}
+
+func TestStableAvailable(t *testing.T) {
+	for _, tc := range []struct {
+		current, latest string
+		want            bool
+	}{
+		{"0.3.7", "0.3.8", true},
+		{"0.3.8", "0.3.8", false},
+		{"0.4.0", "0.3.8", false},
+		{"0.3.9-dev", "0.3.8", true},
+		{"unknown", "0.3.8", true},
+	} {
+		if got := stableAvailable(tc.current, tc.latest); got != tc.want {
+			t.Errorf("stableAvailable(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/floreabogdan/birdy/internal/poller"
 	"github.com/floreabogdan/birdy/internal/snapshot"
 	"github.com/floreabogdan/birdy/internal/store"
+	"github.com/floreabogdan/birdy/internal/updatecheck"
 )
 
 // birdClient is the subset of *birdc.Client the web layer calls directly
@@ -75,6 +76,7 @@ type Server struct {
 	peeringDB bool
 	bgpq4Bin  string // non-empty enables IRR expansion via bgpq4
 	netdiag   bool   // enables ping/traceroute reachability diagnostics
+	updates   updateChecker
 	// listenAddr is where birdy is bound, for the wide-open warning (see access.go).
 	listenAddr string
 	tls        bool
@@ -121,6 +123,7 @@ type Config struct {
 	PeeringDB     bool
 	Bgpq4Bin      string
 	NetDiag       bool
+	UpdateChecker updateChecker
 	// ListenAddr is the address birdy is actually bound to. The UI needs it to
 	// tell "reachable from anywhere with an allow-all access list" (the fresh
 	// install default, worth warning about) from "loopback only" (nothing off-box
@@ -153,6 +156,10 @@ func New(cfg Config) *Server {
 	if applyTimeout <= 0 {
 		applyTimeout = 60
 	}
+	updates := cfg.UpdateChecker
+	if updates == nil {
+		updates = updatecheck.New()
+	}
 	s := &Server{
 		store:         cfg.Store,
 		client:        cfg.Client,
@@ -169,6 +176,7 @@ func New(cfg Config) *Server {
 		peeringDB:     cfg.PeeringDB,
 		bgpq4Bin:      cfg.Bgpq4Bin,
 		netdiag:       cfg.NetDiag,
+		updates:       updates,
 		listenAddr:    cfg.ListenAddr,
 		tls:           cfg.TLS,
 		login:         newLoginLimiter(),
@@ -395,6 +403,8 @@ func (s *Server) routes() {
 	s.mux.Handle("POST /settings/bogons", s.requireAuth(s.handleSettingsBogons))
 	s.mux.Handle("POST /settings/raw", s.requireAuth(s.handleSettingsRaw))
 	s.mux.Handle("POST /settings/access", s.requireAuth(s.handleSettingsAccess))
+	s.mux.Handle("GET /updates", s.requireAuth(s.handleUpdatesPage))
+	s.mux.Handle("POST /updates/channel", s.requireAuth(s.handleUpdateChannel))
 
 	// Alerts (destinations for session notifications).
 	s.mux.Handle("GET /alerts", s.requireAuth(s.handleAlertsList))

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -420,6 +420,34 @@ svg.sparkline[data-spark] { cursor: crosshair; }
 .tab-btn.active { background: var(--btn-primary-bg); border-color: var(--btn-primary-bg); color: #fff; }
 .card-body { padding: 18px; }
 .card-intro { padding: 16px 18px 0; color: var(--text-muted); font-size: 0.8125rem; max-width: 110ch; }
+.choice-list { display: grid; gap: 8px; margin-bottom: 16px; }
+.choice-row {
+	display: flex;
+	align-items: flex-start;
+	gap: 11px;
+	padding: 12px;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-control);
+	background: var(--surface);
+	cursor: pointer;
+}
+.choice-row:hover { background: var(--surface-alt); }
+.choice-row:has(input:checked) {
+	border-color: color-mix(in srgb, var(--primary) 65%, var(--border));
+	background: color-mix(in srgb, var(--primary) 8%, var(--surface));
+}
+.choice-row input { flex: 0 0 auto; margin: 3px 0 0; accent-color: var(--primary); }
+.choice-row > span { display: grid; gap: 3px; }
+.choice-row small { color: var(--text-muted); line-height: 1.4; }
+.choice-row:has(input:disabled) { cursor: not-allowed; opacity: 0.72; }
+.panel-inline {
+	margin-top: 16px;
+	padding: 10px 12px;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-control);
+	font-size: 0.8125rem;
+	overflow-wrap: anywhere;
+}
 
 /* ---------- panels: a card whose header is a tinted band ---------- */
 .panel-head {

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -93,6 +93,7 @@
 
 		<div class="nav-label">System</div>
 		<a href="/settings" class="{{if eq .Active "settings"}}active{{end}}">{{template "icon-settings"}}Settings</a>
+		<a href="/updates" class="{{if eq .Active "updates"}}active{{end}}">{{template "icon-refresh"}}Updates</a>
 	</nav>
 	<div class="sidebar-foot">
 		<div class="conn-line"><span id="bird-conn" class="conn-dot"></span><span id="bird-conn-label">checking BIRD&hellip;</span></div>

--- a/internal/web/templates/updates.html
+++ b/internal/web/templates/updates.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html>
+<head>
+	<title>birdy — updates</title>
+	{{template "head" .}}
+</head>
+<body>
+<div class="app-shell">
+	{{template "sidebar" .}}
+	<div class="main">
+		{{template "topbar" .}}
+		<div class="page">
+			<div class="page-top">
+				<span class="page-eyebrow">System</span>
+				<div class="breadcrumb"><a href="/">Dashboard</a><span class="sep">/</span><span class="current">Updates</span></div>
+			</div>
+			<div class="page-header">
+				<div>
+					<h1>Updates</h1>
+					<div class="page-sub">Application release channel and build status</div>
+				</div>
+			</div>
+
+			{{if .Flash}}<div class="flash flash-success">{{.Flash}}</div>{{end}}
+
+			<div class="grid-2">
+				<div class="card">
+					<div class="card-header"><span class="card-title">Tracking channel</span></div>
+					<div class="card-body">
+						<form method="post" action="/updates/channel">
+							<div class="choice-list">
+								<label class="choice-row">
+									<input type="radio" name="channel" value="stable" {{if eq .Channel "stable"}}checked{{end}} {{if .ReadOnly}}disabled{{end}}>
+									<span><strong>Stable releases</strong><small>Published, versioned builds intended for normal operation.</small></span>
+								</label>
+								<label class="choice-row">
+									<input type="radio" name="channel" value="development" {{if eq .Channel "development"}}checked{{end}} {{if .ReadOnly}}disabled{{end}}>
+									<span><strong>Development branch</strong><small>The latest commit on upstream <code class="mono">main</code>.</small></span>
+								</label>
+							</div>
+							{{if not .ReadOnly}}<button type="submit" class="btn btn-primary">Save channel</button>{{end}}
+						</form>
+					</div>
+				</div>
+
+				<div class="card">
+					<div class="card-header">
+						<span class="card-title">Installed build</span>
+						{{if .CheckErr}}<span class="badge badge-warning">check failed</span>
+						{{else if .Result.Available}}<span class="badge badge-warning">update available</span>
+						{{else}}<span class="badge badge-success">up to date</span>{{end}}
+					</div>
+					<div class="card-body">
+						<dl class="kv">
+							<dt>Version</dt><dd class="mono">{{.BuildVersion}}</dd>
+							<dt>Commit</dt><dd class="mono">{{if and .BuildCommit (ne .BuildCommit "unknown")}}{{shortsha .BuildCommit}}{{else}}not embedded{{end}}</dd>
+							<dt>Channel</dt><dd>{{if eq .Channel "development"}}Development{{else}}Stable{{end}}</dd>
+							{{if .Result.LatestVersion}}<dt>Latest release</dt><dd class="mono">{{.Result.LatestVersion}}</dd>{{end}}
+							{{if .Result.LatestCommit}}<dt>Latest commit</dt><dd class="mono">{{shortsha .Result.LatestCommit}}</dd>{{end}}
+							{{if not .CheckErr}}<dt>Checked</dt><dd>{{fmttime .Result.CheckedAt}}</dd>{{end}}
+						</dl>
+						{{if .CheckErr}}
+							<div class="panel-inline panel-warning">{{.CheckErr}}</div>
+						{{else if .Result.Available}}
+							<a class="btn btn-primary" href="{{.Result.URL}}" target="_blank" rel="noopener">View available {{if eq .Channel "development"}}commit{{else}}release{{end}}</a>
+						{{else}}
+							<a class="btn" href="{{.Result.URL}}" target="_blank" rel="noopener">View current upstream</a>
+						{{end}}
+					</div>
+				</div>
+			</div>
+
+			<div class="card panel-info">
+				<div class="card-body">Channel selection controls update notifications only. Installation remains an explicit package or deployment action, so the web process never replaces its own privileged executable or runs unreviewed branch code.</div>
+			</div>
+		</div>
+	</div>
+</div>
+</body>
+</html>

--- a/internal/web/updates.go
+++ b/internal/web/updates.go
@@ -1,0 +1,70 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/floreabogdan/birdy/internal/buildinfo"
+	"github.com/floreabogdan/birdy/internal/updatecheck"
+)
+
+type updateChecker interface {
+	Check(ctx context.Context, channel, currentVersion, currentCommit string) (updatecheck.Result, error)
+}
+
+type updatesView struct {
+	Active       string
+	ReadOnly     bool
+	Channel      string
+	BuildVersion string
+	BuildCommit  string
+	Result       updatecheck.Result
+	CheckErr     string
+	Flash        string
+}
+
+func (s *Server) handleUpdatesPage(w http.ResponseWriter, r *http.Request) {
+	channel := updatecheck.ChannelStable
+	if settings, ok, err := s.store.GetSettings(); err == nil && ok &&
+		updatecheck.ValidChannel(settings.UpdateChannel) {
+		channel = settings.UpdateChannel
+	}
+	view := updatesView{
+		Active: "updates", ReadOnly: s.readOnly, Channel: channel,
+		BuildVersion: buildinfo.Version, BuildCommit: buildinfo.Commit,
+		Flash: r.URL.Query().Get("flash"),
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 9*time.Second)
+	defer cancel()
+	result, err := s.updates.Check(ctx, channel, buildinfo.Version, buildinfo.Commit)
+	if err != nil {
+		view.CheckErr = err.Error()
+	} else {
+		view.Result = result
+	}
+	render(w, s.log, "updates.html", view)
+}
+
+func (s *Server) handleUpdateChannel(w http.ResponseWriter, r *http.Request) {
+	if s.readOnly {
+		http.Error(w, "birdy is read-only", http.StatusForbidden)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	channel := strings.TrimSpace(r.FormValue("channel"))
+	if !updatecheck.ValidChannel(channel) {
+		http.Error(w, "invalid update channel", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.SaveUpdateChannel(channel); err != nil {
+		s.serverError(w, "save update channel", err)
+		return
+	}
+	s.audit(r, "Update channel changed to "+channel)
+	http.Redirect(w, r, "/updates?flash="+flash("Update channel saved"), http.StatusSeeOther)
+}

--- a/internal/web/updates_handler_test.go
+++ b/internal/web/updates_handler_test.go
@@ -1,0 +1,97 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/floreabogdan/birdy/internal/updatecheck"
+)
+
+type fakeUpdateChecker struct {
+	result  updatecheck.Result
+	err     error
+	channel string
+}
+
+func (f *fakeUpdateChecker) Check(_ context.Context, channel, _, _ string) (updatecheck.Result, error) {
+	f.channel = channel
+	return f.result, f.err
+}
+
+func TestUpdatesPageShowsAvailableDevelopmentCommit(t *testing.T) {
+	checker := &fakeUpdateChecker{result: updatecheck.Result{
+		Channel:      updatecheck.ChannelDevelopment,
+		LatestCommit: "abcdef1234567890",
+		URL:          "https://github.com/floreabogdan/birdy/commit/abcdef1234567890",
+		Available:    true,
+		CheckedAt:    time.Date(2026, 7, 18, 9, 0, 0, 0, time.UTC),
+	}}
+	env := newTestEnv(t, false, func(c *Config) { c.UpdateChecker = checker })
+	if err := env.store.SaveUpdateChannel(updatecheck.ChannelDevelopment); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := env.do(t, http.MethodGet, "/updates", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /updates: status %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Development branch", "update available", "abcdef1", "checked"} {
+		if !strings.Contains(strings.ToLower(body), strings.ToLower(want)) {
+			t.Errorf("GET /updates body missing %q", want)
+		}
+	}
+	if checker.channel != updatecheck.ChannelDevelopment {
+		t.Fatalf("checked channel %q, want development", checker.channel)
+	}
+}
+
+func TestUpdateChannelPost(t *testing.T) {
+	env := newTestEnv(t, false, func(c *Config) {
+		c.UpdateChecker = &fakeUpdateChecker{}
+	})
+	rec := env.do(t, http.MethodPost, "/updates/channel", url.Values{
+		"channel": {updatecheck.ChannelDevelopment},
+	})
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("POST channel: status %d", rec.Code)
+	}
+	settings, ok, err := env.store.GetSettings()
+	if err != nil || !ok {
+		t.Fatalf("GetSettings: ok=%v err=%v", ok, err)
+	}
+	if settings.UpdateChannel != updatecheck.ChannelDevelopment {
+		t.Fatalf("saved channel %q", settings.UpdateChannel)
+	}
+}
+
+func TestUpdateChannelRejectsInvalidAndReadOnly(t *testing.T) {
+	env := newTestEnv(t, false)
+	if rec := env.do(t, http.MethodPost, "/updates/channel", url.Values{
+		"channel": {"feature/untrusted"},
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid channel: status %d", rec.Code)
+	}
+
+	readOnly := newTestEnv(t, true)
+	if rec := readOnly.do(t, http.MethodPost, "/updates/channel", url.Values{
+		"channel": {updatecheck.ChannelDevelopment},
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("read-only channel change: status %d", rec.Code)
+	}
+}
+
+func TestUpdatesPageHandlesCheckFailure(t *testing.T) {
+	env := newTestEnv(t, false, func(c *Config) {
+		c.UpdateChecker = &fakeUpdateChecker{err: errors.New("upstream unavailable")}
+	})
+	rec := env.do(t, http.MethodGet, "/updates", nil)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "upstream unavailable") {
+		t.Fatalf("check failure page: status=%d body=%q", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- add a System > Updates page with stable release and development branch tracking
- persist the selected channel with a schema v31 migration and scoped settings write
- compare stable builds against the latest GitHub release and development builds against upstream `main`
- embed source commit metadata in documented development builds
- bound GitHub responses to 1 MiB, enforce request timeouts, and cache results for 15 minutes

## Security model

The panel is status-only. Selecting a channel never downloads, executes, or installs code and the privileged web process does not replace its own executable. Only the fixed stable and development channels are accepted. The existing authentication, same-origin write checks, read-only mode, and audit log protect channel changes.

## Validation

- `go test ./...`
- `go vet ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` (0 reachable vulnerabilities)
- `git diff --check`

Handler coverage includes rendered availability, stable/development persistence, invalid input, upstream failure, fresh databases, and read-only rejection.