### PR TITLE
fix: protect tunneled peers and clarify pending updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Tunnel underlay protection.** Peers can record an outer GRE, WireGuard, or
+  IPsec endpoint. When BGP-to-kernel export is enabled, generated kernel filters
+  reject every learned prefix covering that endpoint so a full table cannot
+  recursively route the tunnel through itself.
+- **Unapplied-change navigation status.** The Changes menu item now displays a
+  status marker when the model differs from the confirmed config, an apply is
+  awaiting confirmation, or the candidate needs attention.
+
+### Changed
+- **Clear update status.** The Updates page now presents update available, up to
+  date, and check failed states as prominent status panels with direct release
+  or commit actions instead of relying on a small card badge.
+
 ## [0.4.1] - 2026-07-20
 
 ### Fixed

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -655,10 +655,15 @@ button.
     only: Linux forwarding, firewall policy, underlay host routes, and capacity
     monitoring remain operator responsibilities. Birdy excludes any imported
     prefix covering the router ID, configured peer addresses, local session
-    addresses, or preferred source so a full table cannot override the routes
+    addresses, configured tunnel endpoints, or preferred source so a full table cannot override the routes
     that keep the BGP control plane reachable. The default route (0.0.0.0/0,
     ::/0) is exempt from these guards — it covers every address by definition
     and is not a targeted control-plane hijack.
+  - For a BGP session carried over GRE, WireGuard, or IPsec, set **Tunnel
+    endpoint** on the peer to the remote outer address. Birdy then rejects every
+    imported BGP route covering that address from kernel export. Keep an OS-level
+    host route through the underlay as defense in depth, because Birdy manages
+    BIRD configuration rather than the host's tunnel or network configuration.
 - **Bogons** — the bogon prefix lists (v4/v6) and bogon ASN list. Generated filters
   name these directly, which is why they live here rather than in the Library and
   cannot be deleted or announced. "Restore defaults" resets them to what birdy
@@ -689,6 +694,9 @@ button.
   own executable or run code fetched by the web process. Development builds must
   embed their source revision with the documented build `-ldflags` for an exact
   comparison.
+  The page displays a prominent **Update available**, **Up to date**, or
+  **Unable to check** result, with the installed and latest build details and a
+  direct link to the applicable release or commit.
 - **Remote dashboard access** — Settings → General can generate a token that
   grants dashboard data only. On a central Birdy panel, open System → Instances
   and add the remote URL and token. The top-bar selector changes the dashboard

--- a/internal/render/kernel_test.go
+++ b/internal/render/kernel_test.go
@@ -144,6 +144,7 @@ func TestKernelExportProtectsControlPlaneAddresses(t *testing.T) {
 	in.KernelPrefSrcV6 = "2001:db8::100"
 	v4 := ebgpPeer()
 	v4.LocalIP = "192.0.2.1"
+	v4.TransportEndpoint = "198.51.100.200"
 	v6 := ebgpPeer()
 	v6.Name = "edge_v6"
 	v6.NeighborIP = "2001:db8::10"
@@ -152,7 +153,7 @@ func TestKernelExportProtectsControlPlaneAddresses(t *testing.T) {
 
 	cfg := mustRender(t, in)
 	k4 := block(t, cfg, "protocol kernel kernel4 {")
-	for _, addr := range []string{in.RouterID, v4.NeighborIP, v4.LocalIP} {
+	for _, addr := range []string{in.RouterID, v4.NeighborIP, v4.LocalIP, v4.TransportEndpoint} {
 		if !strings.Contains(k4, "if "+addr+" ~ net then reject;") {
 			t.Errorf("kernel4 does not protect %s:\n%s", addr, k4)
 		}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -587,6 +587,7 @@ func kernelProtectedAddrs(in Input, v4 bool) []netip.Addr {
 	for _, peer := range in.Peers {
 		add(peer.NeighborIP)
 		add(peer.LocalIP)
+		add(peer.TransportEndpoint)
 	}
 	out := make([]netip.Addr, 0, len(seen))
 	for addr := range seen {

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -8,7 +8,7 @@ import (
 
 // schemaVersion is the migration level this build expects. Bump it and add a
 // case to migrate() when the shape of an existing database has to change.
-const schemaVersion = 34
+const schemaVersion = 35
 
 // migrate brings an existing database up to schemaVersion. The CREATE TABLE
 // statements in schema.go are all IF NOT EXISTS and run unconditionally, so
@@ -439,6 +439,15 @@ func migrate(db *sql.DB) error {
 			scope TEXT NOT NULL DEFAULT 'dashboard timeline', expires_at TEXT NOT NULL DEFAULT '',
 			revoked INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL, last_used TEXT NOT NULL DEFAULT '')`); err != nil {
 			return fmt.Errorf("create instance tokens: %w", err)
+		}
+	}
+	if version < 35 {
+		// A tunneled BGP neighbor's inner address is not enough to protect the
+		// session when full routes are exported to the host FIB. Record the outer
+		// GRE/WireGuard/IPsec endpoint so every covering BGP route is rejected by
+		// the generated kernel filter and the tunnel cannot route through itself.
+		if err := ensureColumn(tx, "peers", "transport_endpoint", `ALTER TABLE peers ADD COLUMN transport_endpoint TEXT NOT NULL DEFAULT ''`); err != nil {
+			return err
 		}
 	}
 

--- a/internal/store/model_test.go
+++ b/internal/store/model_test.go
@@ -102,6 +102,19 @@ func TestPeerIsV6(t *testing.T) {
 	}
 }
 
+func TestPeerValidatesTransportEndpoint(t *testing.T) {
+	p := validPeer()
+	p.TransportEndpoint = "not-an-address"
+	if _, ok := p.Validate()["transportEndpoint"]; !ok {
+		t.Fatal("invalid tunnel endpoint was accepted")
+	}
+	p = validPeer()
+	p.TransportEndpoint = "2001:db8::200"
+	if errs := p.Validate(); len(errs) != 0 {
+		t.Fatalf("valid tunnel endpoint rejected: %v", errs)
+	}
+}
+
 func TestPeerCRUD(t *testing.T) {
 	s := openTest(t)
 
@@ -118,12 +131,13 @@ func TestPeerCRUD(t *testing.T) {
 	}
 
 	got.Description = "transit"
+	got.TransportEndpoint = "198.51.100.200"
 	got.Enabled = false
 	if err := s.UpdatePeer(got); err != nil {
 		t.Fatalf("UpdatePeer: %v", err)
 	}
 	again, _ := s.GetPeer(id)
-	if again.Description != "transit" || again.Enabled {
+	if again.Description != "transit" || again.Enabled || again.TransportEndpoint != "198.51.100.200" {
 		t.Errorf("update did not stick: %+v", again)
 	}
 

--- a/internal/store/peers.go
+++ b/internal/store/peers.go
@@ -78,6 +78,7 @@ type Peer struct {
 	RemoteASN         int64
 	LocalIP           string
 	Interface         string // required when local or neighbor is link-local
+	TransportEndpoint string // outer endpoint for a GRE/WireGuard/IPsec session
 	Multihop          int    // 0 = direct
 	Passive           bool
 	Password          string
@@ -236,6 +237,15 @@ func (p *Peer) Validate() map[string]string {
 			errs["interface"] = "Enter a valid Linux interface name (up to 15 characters, no spaces or quotes)."
 		}
 	}
+	p.TransportEndpoint = strings.TrimSpace(p.TransportEndpoint)
+	if p.TransportEndpoint != "" {
+		endpoint, endpointErr := netip.ParseAddr(p.TransportEndpoint)
+		if endpointErr != nil || !endpoint.IsValid() || endpoint.IsUnspecified() {
+			errs["transportEndpoint"] = "Enter the tunnel's outer IPv4 or IPv6 endpoint."
+		} else {
+			p.TransportEndpoint = endpoint.String()
+		}
+	}
 
 	// BGP AS numbers are 32-bit. AS0 (RFC 7607), AS65535 and AS4294967295
 	// (RFC 7300) are reserved and never valid on the wire; AS23456 is AS_TRANS
@@ -269,7 +279,7 @@ func (p *Peer) Validate() map[string]string {
 // Kept in one place because it is read by three queries and must stay aligned
 // with the scan, INSERT and UPDATE — the widest such surface in the store.
 const peerCols = `id, name, description, role, enabled, neighbor_ip, remote_asn, local_ip,
-	interface, multihop, passive, password, import_limit, import_limit_action, enforce_first_as,
+	interface, transport_endpoint, multihop, passive, password, import_limit, import_limit_action, enforce_first_as,
 	origin_peer_only, next_hop_self, rr_client,
 	prepend_count, import_communities, export_communities, drained, bfd, bgp_role, gtsm, graceful_restart`
 
@@ -316,7 +326,7 @@ type scanner interface{ Scan(...any) error }
 func scanPeer(sc scanner) (Peer, error) {
 	var p Peer
 	err := sc.Scan(&p.ID, &p.Name, &p.Description, &p.Role, &p.Enabled, &p.NeighborIP,
-		&p.RemoteASN, &p.LocalIP, &p.Interface, &p.Multihop, &p.Passive, &p.Password,
+		&p.RemoteASN, &p.LocalIP, &p.Interface, &p.TransportEndpoint, &p.Multihop, &p.Passive, &p.Password,
 		&p.ImportLimit, &p.ImportLimitAction, &p.EnforceFirstAS, &p.OriginPeerOnly,
 		&p.NextHopSelf, &p.RRClient,
 		&p.PrependCount, &p.ImportCommunities, &p.ExportCommunities, &p.Drained, &p.BFD, &p.BGPRole, &p.GTSM, &p.GracefulRestart)
@@ -327,12 +337,12 @@ func (s *Store) CreatePeer(p Peer) (int64, error) {
 	ts := now()
 	res, err := s.db.Exec(`
 		INSERT INTO peers (name, description, role, enabled, neighbor_ip, remote_asn, local_ip,
-		                   interface, multihop, passive, password, import_limit, import_limit_action,
+		                   interface, transport_endpoint, multihop, passive, password, import_limit, import_limit_action,
 		                   enforce_first_as, origin_peer_only, next_hop_self, rr_client,
 		                   prepend_count, import_communities, export_communities, drained, bfd, bgp_role, gtsm, graceful_restart, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		p.Name, p.Description, p.Role, p.Enabled, p.NeighborIP, p.RemoteASN, p.LocalIP,
-		p.Interface, p.Multihop, p.Passive, p.Password, p.ImportLimit, p.ImportLimitAction,
+		p.Interface, p.TransportEndpoint, p.Multihop, p.Passive, p.Password, p.ImportLimit, p.ImportLimitAction,
 		p.EnforceFirstAS, p.OriginPeerOnly, p.NextHopSelf, p.RRClient,
 		p.PrependCount, p.ImportCommunities, p.ExportCommunities, p.Drained, p.BFD, p.BGPRole, p.GTSM, p.GracefulRestart, ts, ts)
 	if err != nil {
@@ -344,14 +354,14 @@ func (s *Store) CreatePeer(p Peer) (int64, error) {
 func (s *Store) UpdatePeer(p Peer) error {
 	res, err := s.db.Exec(`
 		UPDATE peers SET name = ?, description = ?, role = ?, enabled = ?, neighbor_ip = ?,
-		                 remote_asn = ?, local_ip = ?, interface = ?, multihop = ?, passive = ?,
+		                 remote_asn = ?, local_ip = ?, interface = ?, transport_endpoint = ?, multihop = ?, passive = ?,
 		                 password = ?, import_limit = ?, import_limit_action = ?, enforce_first_as = ?,
 		                 origin_peer_only = ?, next_hop_self = ?, rr_client = ?,
 		                 prepend_count = ?, import_communities = ?, export_communities = ?, drained = ?, bfd = ?, bgp_role = ?,
 			                 gtsm = ?, graceful_restart = ?, updated_at = ?
 		WHERE id = ?`,
 		p.Name, p.Description, p.Role, p.Enabled, p.NeighborIP, p.RemoteASN, p.LocalIP,
-		p.Interface, p.Multihop, p.Passive, p.Password, p.ImportLimit, p.ImportLimitAction,
+		p.Interface, p.TransportEndpoint, p.Multihop, p.Passive, p.Password, p.ImportLimit, p.ImportLimitAction,
 		p.EnforceFirstAS, p.OriginPeerOnly, p.NextHopSelf, p.RRClient,
 		p.PrependCount, p.ImportCommunities, p.ExportCommunities, p.Drained, p.BFD, p.BGPRole, p.GTSM, p.GracefulRestart, now(), p.ID)
 	if err != nil {

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -102,6 +102,7 @@ CREATE TABLE IF NOT EXISTS peers (
 	remote_asn           INTEGER NOT NULL,
 	local_ip             TEXT NOT NULL DEFAULT '',
 	interface            TEXT NOT NULL DEFAULT '',
+	transport_endpoint   TEXT NOT NULL DEFAULT '',
 	multihop             INTEGER NOT NULL DEFAULT 0,
 	passive              INTEGER NOT NULL DEFAULT 0,
 	password             TEXT NOT NULL DEFAULT '',

--- a/internal/web/change_status.go
+++ b/internal/web/change_status.go
@@ -1,0 +1,36 @@
+package web
+
+import (
+	"net/http"
+
+	birdconf "github.com/floreabogdan/birdy/internal/render"
+)
+
+// apiChangeStatus gives the global navigation a cheap, explicit signal that
+// the model differs from the last confirmed configuration. It is requested
+// once per page load rather than folding config rendering into the fast BIRD
+// status poll.
+func (s *Server) apiChangeStatus(w http.ResponseWriter, _ *http.Request) {
+	settings, _, err := s.store.GetSettings()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not read settings")
+		return
+	}
+	pending, _, err := s.store.PendingConfigVersion()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not read apply state")
+		return
+	}
+	in, reason, err := s.renderInput(false)
+	if err != nil || reason != "" {
+		writeJSON(w, map[string]any{"changed": true, "pending": pending.ID != 0, "blocked": true})
+		return
+	}
+	candidate, err := birdconf.Config(in)
+	if err != nil {
+		writeJSON(w, map[string]any{"changed": true, "pending": pending.ID != 0, "blocked": true})
+		return
+	}
+	changed := settings.AppliedConfigHash == "" || hashBytes([]byte(candidate)) != settings.AppliedConfigHash
+	writeJSON(w, map[string]any{"changed": changed, "pending": pending.ID != 0, "blocked": false})
+}

--- a/internal/web/change_status_test.go
+++ b/internal/web/change_status_test.go
@@ -1,0 +1,49 @@
+package web
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	birdconf "github.com/floreabogdan/birdy/internal/render"
+	"github.com/floreabogdan/birdy/internal/store"
+)
+
+func TestChangeStatusTracksAppliedModel(t *testing.T) {
+	env := newTestEnv(t, false)
+	if err := env.store.SaveSettings(store.Settings{
+		RouterID: "192.0.2.1", LocalASN: sql.NullInt64{Int64: 65551, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	status := func() map[string]bool {
+		rec := env.do(t, http.MethodGet, "/api/changes/status", nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		var body map[string]bool
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatal(err)
+		}
+		return body
+	}
+	if !status()["changed"] {
+		t.Fatal("unadopted model must report changes")
+	}
+
+	in, reason, err := env.srv.renderInput(false)
+	if err != nil || reason != "" {
+		t.Fatalf("render input: %s %v", reason, err)
+	}
+	cfg, err := birdconf.Config(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.store.SetAppliedConfigHash(hashBytes([]byte(cfg))); err != nil {
+		t.Fatal(err)
+	}
+	if status()["changed"] {
+		t.Fatal("matching applied hash reported changes")
+	}
+}

--- a/internal/web/peers.go
+++ b/internal/web/peers.go
@@ -87,7 +87,7 @@ func (s *Server) handlePeerNew(w http.ResponseWriter, r *http.Request) {
 				s.serverError(w, "peer policies", err)
 				return
 			}
-			src.ID, src.Name, src.NeighborIP, src.LocalIP, src.Interface, src.RemoteASN, src.Password = 0, "", "", "", "", 0, ""
+			src.ID, src.Name, src.NeighborIP, src.LocalIP, src.Interface, src.TransportEndpoint, src.RemoteASN, src.Password = 0, "", "", "", "", "", 0, ""
 			src.Drained = false // a fresh session is not in maintenance
 			s.renderPeerForm(w, peerFormView{Active: "peers", ReadOnly: s.readOnly, IsNew: true, Peer: src, ClonedFrom: from})
 			return
@@ -139,6 +139,7 @@ func peerFromForm(r *http.Request) store.Peer {
 		RemoteASN:         int64(formInt(r, "remoteAsn")),
 		LocalIP:           r.FormValue("localIp"),
 		Interface:         r.FormValue("interface"),
+		TransportEndpoint: r.FormValue("transportEndpoint"),
 		Multihop:          formInt(r, "multihop"),
 		Passive:           r.FormValue("passive") == "on",
 		Password:          r.FormValue("password"),

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -500,4 +500,5 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/backup/download", s.requireAuth(s.handleBackupDownload))
 	s.mux.Handle("POST /api/snapshot/restore", s.requireAuth(s.apiSnapshotRestore))
 	s.mux.Handle("GET /api/alerts/summary", s.requireAuth(s.apiAlertsSummary))
+	s.mux.Handle("GET /api/changes/status", s.requireAuth(s.apiChangeStatus))
 }

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -363,6 +363,10 @@ h1, h2, h3 { font-weight: 700; color: var(--text); margin: 0; }
 .conn-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sidebar-text); display: inline-block; flex-shrink: 0; }
 .conn-dot.ok { background: var(--success); }
 .conn-dot.bad { background: var(--danger); }
+.nav-status-dot { width:8px; height:8px; margin-left:auto; flex:0 0 8px; border-radius:50%; background:var(--warning); box-shadow:0 0 0 2px color-mix(in srgb, var(--warning) 20%, transparent); }
+.nav-status-dot.is-pending { background:var(--info); box-shadow:0 0 0 2px color-mix(in srgb, var(--info) 20%, transparent); }
+.nav-status-dot.is-blocked { background:var(--danger); box-shadow:0 0 0 2px color-mix(in srgb, var(--danger) 20%, transparent); }
+body.sidebar-collapsed .nav-status-dot { position:absolute; right:7px; top:7px; }
 
 .main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 
@@ -811,6 +815,16 @@ td.num, th.num { text-align: right; }
 .hero-status.ok { color: var(--success-deep); border-color: color-mix(in srgb, var(--success) 40%, transparent); }
 .hero-status.bad { color: var(--danger-deep); border-color: color-mix(in srgb, var(--danger) 40%, transparent); }
 .hero-updated { font-size: 0.75rem; color: var(--text-muted); }
+
+.update-status { display:flex; align-items:center; gap:12px; min-height:68px; padding:14px 16px; margin-bottom:16px; border:1px solid var(--border); border-left-width:4px; background:var(--surface); }
+.update-status > svg { width:22px; height:22px; flex:0 0 auto; }
+.update-status > div { display:flex; flex:1; min-width:0; flex-direction:column; gap:3px; }
+.update-status strong { font-size:0.95rem; }
+.update-status span { color:var(--text-muted); font-size:0.84rem; }
+.update-status.is-available { border-left-color:var(--warning); }
+.update-status.is-current { border-left-color:var(--success); }
+.update-status.is-error { border-left-color:var(--danger); }
+@media (max-width: 640px) { .update-status { align-items:flex-start; flex-wrap:wrap; } .update-status .btn { width:100%; } }
 
 /* ---------- section headings that sit on the page canvas, not in a card ---------- */
 .section-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 26px 0 12px; }

--- a/internal/web/static/ui.js
+++ b/internal/web/static/ui.js
@@ -1,4 +1,20 @@
 (function () {
+	var changesIndicator = document.getElementById("changes-nav-indicator");
+	if (changesIndicator) {
+		fetch("/api/changes/status", { headers: { "Accept": "application/json" } })
+			.then(function (response) { if (!response.ok) throw new Error("status"); return response.json(); })
+			.then(function (status) {
+				if (!status.changed && !status.pending) return;
+				var label = status.pending ? "Configuration awaiting confirmation" :
+					(status.blocked ? "Configuration changes need attention" : "Configuration changes ready to apply");
+				changesIndicator.hidden = false;
+				changesIndicator.classList.toggle("is-pending", !!status.pending);
+				changesIndicator.classList.toggle("is-blocked", !!status.blocked);
+				changesIndicator.setAttribute("aria-label", label);
+				changesIndicator.title = label;
+			});
+	}
+
 	var sidebarCollapse = document.getElementById("sidebar-collapse");
 	if (sidebarCollapse) {
 		var collapsed = false;

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -1,10 +1,10 @@
 {{define "head"}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/static/style.css?v=dev-ui12">
+<link rel="stylesheet" href="/static/style.css?v=dev-ui13">
 <script src="/static/theme-bootstrap.js?v=dev-ui12"></script>
 <script src="/static/theme.js?v=dev-ui10" defer></script>
-<script src="/static/ui.js?v=dev-ui12" defer></script>
+<script src="/static/ui.js?v=dev-ui13" defer></script>
 <script src="/static/command-palette.js?v=dev-ui12" defer></script>
 {{end}}
 
@@ -94,7 +94,7 @@
 		{{if eq .Active "policies"}}<div class="sidebar-subnav"><a href="/policies">All policies</a><a href="/policies/new">Add policy</a></div>{{end}}
 		<a href="/library/prefix-sets" title="Library" class="{{if eq .Active "library"}}active{{end}}">{{template "icon-library"}}<span class="nav-copy">Library</span></a>
 		{{if eq .Active "library"}}<div class="sidebar-subnav"><a href="/library/prefix-sets">Prefix sets</a><a href="/library/as-sets">AS sets</a><a href="/library/communities">Communities</a><a href="/library/static-routes">Static routes</a></div>{{end}}
-		<a href="/changes" title="Changes" class="{{if eq .Active "changes"}}active{{end}}">{{template "icon-changes"}}<span class="nav-copy">Changes</span></a>
+		<a href="/changes" title="Changes" class="{{if eq .Active "changes"}}active{{end}}">{{template "icon-changes"}}<span class="nav-copy">Changes</span><span id="changes-nav-indicator" class="nav-status-dot" hidden aria-label=""></span></a>
 		{{if eq .Active "changes"}}<div class="sidebar-subnav"><a href="/changes">Candidate</a><a href="/changes/history">Apply history</a></div>{{end}}
 
 		<div class="nav-label">Protect</div>

--- a/internal/web/templates/peer_form.html
+++ b/internal/web/templates/peer_form.html
@@ -127,6 +127,12 @@
 									<div class="hint">Required when using link-local addresses (e.g. eth0).</div>
 									{{with index .Errs "interface"}}<div class="field-error">{{.}}</div>{{end}}
 								</div>
+								<div class="field">
+									<label for="transportEndpoint">Tunnel endpoint</label>
+									<input type="text" id="transportEndpoint" name="transportEndpoint" class="mono" value="{{.Peer.TransportEndpoint}}" placeholder="optional outer IP" autocomplete="off">
+									<div class="hint">For GRE, WireGuard or IPsec, enter the remote outer IP. Birdy keeps routes covering it out of the kernel FIB.</div>
+									{{with index .Errs "transportEndpoint"}}<div class="field-error">{{.}}</div>{{end}}
+								</div>
 							</div>
 						</div>
 					</div>

--- a/internal/web/templates/updates.html
+++ b/internal/web/templates/updates.html
@@ -23,6 +23,21 @@
 
 			{{if .Flash}}<div class="flash flash-success">{{.Flash}}</div>{{end}}
 
+			{{if .CheckErr}}
+			<div class="update-status is-error" role="alert">
+				{{template "icon-alert"}}<div><strong>Unable to check for updates</strong><span>{{.CheckErr}}</span></div>
+			</div>
+			{{else if .Result.Available}}
+			<div class="update-status is-available" role="status">
+				{{template "icon-download"}}<div><strong>Update available</strong><span>{{if eq .Channel "development"}}A newer development commit is ready.{{else}}Birdy {{.Result.LatestVersion}} is newer than the installed {{.BuildVersion}} build.{{end}}</span></div>
+				<a class="btn btn-primary" href="{{.Result.URL}}" target="_blank" rel="noopener">View {{if eq .Channel "development"}}commit{{else}}release{{end}}</a>
+			</div>
+			{{else}}
+			<div class="update-status is-current" role="status">
+				{{template "icon-check"}}<div><strong>Birdy is up to date</strong><span>The installed build matches the latest {{if eq .Channel "development"}}development commit{{else}}stable release{{end}}.</span></div>
+			</div>
+			{{end}}
+
 			<div class="grid-2">
 				<div class="card">
 					<div class="card-header"><span class="card-title">Tracking channel</span></div>

--- a/internal/web/updates_handler_test.go
+++ b/internal/web/updates_handler_test.go
@@ -41,13 +41,25 @@ func TestUpdatesPageShowsAvailableDevelopmentCommit(t *testing.T) {
 		t.Fatalf("GET /updates: status %d", rec.Code)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Development branch", "update available", "abcdef1", "checked"} {
+	for _, want := range []string{"Development branch", "Update available", "A newer development commit is ready", "abcdef1", "checked"} {
 		if !strings.Contains(strings.ToLower(body), strings.ToLower(want)) {
 			t.Errorf("GET /updates body missing %q", want)
 		}
 	}
 	if checker.channel != updatecheck.ChannelDevelopment {
 		t.Fatalf("checked channel %q, want development", checker.channel)
+	}
+}
+
+func TestUpdatesPageClearlyShowsCurrentBuild(t *testing.T) {
+	checker := &fakeUpdateChecker{result: updatecheck.Result{
+		Channel: updatecheck.ChannelStable, LatestVersion: "0.4.0",
+		URL: "https://github.com/floreabogdan/birdy/releases/tag/v0.4.0", CheckedAt: time.Now(),
+	}}
+	env := newTestEnv(t, false, func(c *Config) { c.UpdateChecker = checker })
+	body := env.do(t, http.MethodGet, "/updates", nil).Body.String()
+	if !strings.Contains(body, "Birdy is up to date") {
+		t.Fatalf("current update state is not prominent: %q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

This adds three related operator-safety improvements:

- model a tunnel's outer transport endpoint on each peer and protect it in generated kernel-export filters
- make update-check results prominent and unambiguous
- show an indicator beside **Changes** when configuration is unapplied, pending confirmation, or blocked

## Why

While testing full-table transit over GRE, the inner BGP neighbor remained protected by Birdy's existing kernel guards, but the tunnel's outer endpoint was not represented in the model. If a learned route covering that outer endpoint is installed into the Linux FIB, the tunnel can recursively route through itself and take down its own BGP sessions.

The immediate operational mitigation is an underlay host route, but Birdy's generated configuration should also protect operators who enable BGP-to-kernel export. The outer endpoint therefore needs to be explicit model data rather than a host-specific hard-coded address.

The panel also made two important states too easy to miss: an available Birdy update was represented by a small badge, and unapplied configuration had no indication in global navigation.

## Implementation

### Tunnel transport protection

- schema migration 35 adds optional `peers.transport_endpoint`
- peer create, edit, clone, persistence, and validation paths carry the field end to end
- the peer form explains that this is the outer GRE, WireGuard, or IPsec endpoint
- malformed or unspecified addresses are rejected at the model boundary
- generated kernel filters reject any non-default BGP prefix containing a configured transport endpoint
- existing peers remain unchanged because the field defaults to empty

This uses the same containment guard already used for router IDs, peer addresses, local session addresses, and preferred source addresses. Birdy still does not manage Linux tunnel interfaces or host routes, so the documentation retains an underlay host route as defense in depth.

### Changes navigation indicator

A lightweight authenticated endpoint compares the freshly rendered candidate hash with the last confirmed applied hash once per page load. The Changes menu item displays:

- amber for unapplied model changes
- blue for an apply awaiting confirmation
- red when the candidate cannot render and needs attention
- no marker when the model and confirmed configuration match

This is separate from the frequent BIRD status poll so config rendering is not added to the fast monitoring path.

### Update status

The Updates page now displays a prominent accessible status panel for:

- update available
- installed build is current
- update check failed

Available updates include a direct release or commit action. Styling works with the existing themes and responsive layout.

## Safety and compatibility

- migration is forward-only and backward-compatible for existing peer rows
- transport endpoints affect only BGP route export to the kernel FIB
- BGP import/export policy and session rendering are unchanged
- default-route handling retains the existing kernel guard semantics
- status endpoints require normal authenticated access
- no automatic update installation or configuration apply behavior was added

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/birdy`
- regression coverage for transport endpoint validation, database round trips, kernel-filter generation, applied-model status, update available, and up-to-date states
